### PR TITLE
allowing custom messages and channels for the slack recovery message

### DIFF
--- a/src/commands/send-slack-on-workflow-recovery.yml
+++ b/src/commands/send-slack-on-workflow-recovery.yml
@@ -1,4 +1,12 @@
 description: Send a Slack message to a channel if the workflow has recovered
+parameters:
+  channel:
+    description: >
+      The channel to send the slack notification to. Defaults to empty string which is the web-hooks default channel.
+    type: string
+  message:
+    description: The message to send with the slack notification
+    type: string
 steps:
   - run:
       name: Check if the workflow has recovered
@@ -35,5 +43,6 @@ steps:
       include_project_field: false
       include_job_number_field: false
       include_visit_job_action: false
-      message: ":tada: $WORKFLOW_LOCK_KEY has recovered!"
+      channel: << parameters.channel >>
+      message: << parameters.message >>
       color: "#1CBF43"

--- a/src/jobs/exit-queue.yml
+++ b/src/jobs/exit-queue.yml
@@ -4,6 +4,15 @@ parameters:
     description: If true, the default channel will be notified on workflow recovery
     type: boolean
     default: false
+  channel:
+    description: >
+      The channel to send the slack notification to. Defaults to empty string which is the web-hooks default channel.
+    type: string
+    default: ""
+  message:
+    description: The message to send with the slack notification
+    type: string
+    default: ":tada: $WORKFLOW_LOCK_KEY has recovered!"
 machine:
   enabled: true
 steps:
@@ -12,4 +21,7 @@ steps:
   - when:
       condition: << parameters.send_slack_on_recovery >>
       steps:
-        - send-slack-on-workflow-recovery
+        - send-slack-on-workflow-recovery:
+            channel: << parameters.channel >>
+            message: << parameters.message >>
+


### PR DESCRIPTION
# Overview:
Needed the ability to publish slack messages to channels other than the default web-hook channel. This adds the generics while still maintaining the defaults so we can push custom messages to any channel using the workflow manager.

@jdrake can you publish this please