### PR TITLE
Move to the NS:Slack Orb instead of the CCI built in

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,4 +8,4 @@ display:
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.19
-  slack: circleci/slack@3.4.1
+  slack: narrativescience/slack@0.1.0


### PR DESCRIPTION
# Overview: 
Allows the ability to provide a custom channel or mention in slack messages.