### PR TITLE
QPT-32618: Updating the set-state command to set the pager for AWS CLI v2

### DIFF
--- a/src/commands/set-state.yml
+++ b/src/commands/set-state.yml
@@ -32,6 +32,9 @@ steps:
           > "$VALUES"
         cat "$VALUES"
 
+        # Set the AWS_PAGER var to be set as empty so if we are using AWSCLI V2 this command works
+        echo 'export AWS_PAGER=""' >> $BASH_ENV
+
         # Update the state item and return the updated item
         # The key object is stored in /tmp/workspace/workflow-key.json
         aws dynamodb update-item \


### PR DESCRIPTION
# Overview:
This PR adds a temporary fix for users that use this command in a AWS CLI V2 enabled executor. With the V2 update you need to set the pager because by default AWS uses a pager program for all responses.

This will be fixed in a major release of this orb when we migrate it to AWS CLI V2. For now this will handle both versions while using the set state command.