### PR TITLE
QPT-32618: Setting pager var for single command only

### DIFF
--- a/src/commands/set-state.yml
+++ b/src/commands/set-state.yml
@@ -32,12 +32,9 @@ steps:
           > "$VALUES"
         cat "$VALUES"
 
-        # Set the AWS_PAGER var to be set as empty so if we are using AWSCLI V2 this command works
-        echo 'export AWS_PAGER=""' >> $BASH_ENV
-
         # Update the state item and return the updated item
         # The key object is stored in /tmp/workspace/workflow-key.json
-        aws dynamodb update-item \
+        AWS_PAGER="" && aws dynamodb update-item \
           --table-name "$DYNAMODB_TABLE_WORKFLOWS" \
           --key "file:///tmp/workspace/workflow-key.json" \
           --update-expression 'SET #state.#key = :value' \

--- a/src/commands/set-state.yml
+++ b/src/commands/set-state.yml
@@ -34,7 +34,7 @@ steps:
 
         # Update the state item and return the updated item
         # The key object is stored in /tmp/workspace/workflow-key.json
-        AWS_PAGER="" && aws dynamodb update-item \
+        AWS_PAGER="" aws dynamodb update-item \
           --table-name "$DYNAMODB_TABLE_WORKFLOWS" \
           --key "file:///tmp/workspace/workflow-key.json" \
           --update-expression 'SET #state.#key = :value' \


### PR DESCRIPTION
# Overview:
This will set the pager command in line with the dynamo db update command vs exporting to the bash env