### PR TITLE
BUG FIX: Fix empty commit for a new workflow

### DIFF
--- a/src/commands/wait-in-queue.yml
+++ b/src/commands/wait-in-queue.yml
@@ -136,6 +136,21 @@ steps:
         # Check if this workflow is at the front of the queue
         function isWorkflowFrontOfQueue() {
           (
+            # are there any items in this table that match our workflow lock key
+            local values="$(
+              echo '{}' \
+              | jq --arg k "$LOCK_KEY" '.[":key"].S = $k' - )"
+            count="$(aws dynamodb scan \
+              --table-name "$DYNAMODB_TABLE_WORKFLOWS" \
+              --filter-expression "#key = :key" \
+              --expression-attribute-names '{"#key": "key"}' \
+              --expression-attribute-values "$values" \
+              --select COUNT | jq .Count)"
+            if [[ $count -eq 0 ]]; then
+              echo "There were no commits found for this lock key: $LOCK_KEY"
+              exit 0
+            fi
+
             # Check that previous commit was processed. This means it has an item in
             # the workflows table.
             #


### PR DESCRIPTION
# Overview:
Before checking if we are at the front of the queue check if there have been any commits at all for this workflow lock key. If yes, continue with checking, if not... exit 0 because we will not find a commit.