### PR TITLE
@W-11894453: BUG FIX - Conditional Logic Backwards

### DIFF
--- a/src/commands/cancel-job.yml
+++ b/src/commands/cancel-job.yml
@@ -35,7 +35,8 @@ steps:
           echo ${OUTPUT}
 
           STATUS="$(echo "$OUTPUT" | jq -r .status -)"
-          if [[ "$STATUS" == 'canceled' ]]; then
+          # Make sure the job was acutally cancelled - if not wait.
+          if [[ "$STATUS" != 'canceled' ]]; then
             # This means the job was cancelled but for some reason the current script is
             # still running. Wait a few seconds to let it catch up then fail the job to
             # prevent downstream jobs from running unintentionally.


### PR DESCRIPTION
# Overview
Conditional cancel logic for a "cancel" job was backwards. When we would do a POST to /cancel for a specific job it would return `status: running` when it should have been `status: cancelled`. This looks to be a slow down in CCI's API and job responses. We never hit this conditional before which had the "wait" logic already there but the condition was backwards. This now works as it should

# Testing
Tested in another job by copying the cancel logic manually and debugging